### PR TITLE
Adjust struct check for data size

### DIFF
--- a/Platform/demo/hal/demo_hal.c
+++ b/Platform/demo/hal/demo_hal.c
@@ -54,7 +54,7 @@ void HAL_sys_getTime(uint32_t *unix_timestamp) {
 SAT_returnState HAL_hk_report(uint8_t sid, void *output) {
   switch (sid) {
     case BATTERY_1:
-      if ((sizeof((char *) output) + 1) > csp_buffer_data_size() - 2) {
+     if ( sizeof(HK_battery) > (csp_buffer_data_size() - 2)) {
 		    return CSP_ERR_NOMEM;
     	};
       HK_battery *battery1 = (HK_battery *)output;


### PR DESCRIPTION
Replace origin data size check to make sure that the data field of the CSP packets is large enough to hold the battery struct. 
