### PR TITLE
fix: Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN python3 waf build
 # build this codebase
 WORKDIR /home/ex2_command_handling_demo
 COPY . .
-RUN gcc ex2_demo_software/*.c Platform/demo/*.c Platform/demo/hal/*.c Services/*.c -c -I . -I ex2_demo_software/ -I Platform/demo -I Platform/demo/hal -I Services/ -I ../upsat-ecss-services/services/ -I ../SatelliteSim/Source/include/ -I ../SatelliteSim/Project/ -I ../SatelliteSim/libcsp/include/ -I ../SatelliteSim/Source/portable/GCC/POSIX/ -I ../SatelliteSim/libcsp/build/include/ -lpthread -std=c99 -lrt && ar -rsc client_server.a *.o
+RUN gcc ex2_demo_software/*.c Platform/demo/*.c Platform/demo/hal/*.c Services/*.c -c -D SYSTEM_APP_ID=_DEMO_APP_ID_ -I . -I ex2_demo_software/ -I Platform/demo -I Platform/demo/hal -I Services/ -I ../upsat-ecss-services/services/ -I ../SatelliteSim/Source/include/ -I ../SatelliteSim/Project/ -I ../SatelliteSim/libcsp/include/ -I ../SatelliteSim/Source/portable/GCC/POSIX/ -I ../SatelliteSim/libcsp/build/include/ -lpthread -std=c99 -lrt && ar -rsc client_server.a *.o
 
 WORKDIR /home/SatelliteSim
 RUN make clean && make all

--- a/Platform/demo/demo.h
+++ b/Platform/demo/demo.h
@@ -40,7 +40,7 @@ extern unsigned int sent_count;
 // Defined here are the services implemented by this platform
 typedef struct {
   xQueueHandle response_queue,  // Each platform must define a response queue
-      hk_app_queue, time_management_app_queue;
+      hk_app_queue, time_management_app_queue, communication_app_queue;
 } Service_Queues_t;
 
 SAT_returnState start_service_handlers();

--- a/Services/housekeeping_service.c
+++ b/Services/housekeeping_service.c
@@ -27,12 +27,7 @@
 #include "service_response.h"
 #include "service_utilities.h"
 #include "services.h"
-
-#if SYSTEM_APP_ID == _DEMO_APP_ID_
-#include "ex2_demo_software/system.h"
-#elif SYSTEM_APP_ID == _OBC_APP_ID_
-#include "ex2_obc_software/system.h"
-#endif
+#include "system_header.h"
 
 static uint8_t SID_byte = 1;
 extern Service_Queues_t service_queues;

--- a/Services/service_response.c
+++ b/Services/service_response.c
@@ -25,12 +25,7 @@
 
 #include "service_utilities.h"
 #include "services.h"
-
-#if SYSTEM_APP_ID == _DEMO_APP_ID_
-#include "ex2_demo_software/system.h"
-#elif SYSTEM_APP_ID == _OBC_APP_ID_
-#include "ex2_obc_software/system.h"
-#endif
+#include "system_header.h"
 
 extern Service_Queues_t service_queues;  // Implemented by the host platform
 

--- a/Services/services.c
+++ b/Services/services.c
@@ -24,12 +24,7 @@
 #include <task.h>
 
 #include "service_utilities.h"
-
-#if SYSTEM_APP_ID == _DEMO_APP_ID_
-#include "ex2_demo_software/system.h"
-#elif SYSTEM_APP_ID == _OBC_APP_ID_
-#include "ex2_obc_software/system.h"
-#endif
+#include "system_header.h"
 
 extern Service_Queues_t service_queues;
 

--- a/Services/subsystems_ids.h
+++ b/Services/subsystems_ids.h
@@ -39,7 +39,11 @@
  */
 
 /* Space Segment */
-#define _OBC_APP_ID_ 0
+/*  
+    Don't define any ID as 0. If SYSTEM_APP_ID is undefined some compilers
+    assumes 0 is the default value and can break some preprocessor statements
+*/
+#define _OBC_APP_ID_ 1
 #define _EPS_APP_ID_ 4
 #define _ADCS_APP_ID_ 2
 #define _COMMS_APP_ID_ 3

--- a/Services/subsystems_ids.h
+++ b/Services/subsystems_ids.h
@@ -39,11 +39,7 @@
  */
 
 /* Space Segment */
-/*  
-    Don't define any ID as 0. If SYSTEM_APP_ID is undefined some compilers
-    assumes 0 is the default value and can break some preprocessor statements
-*/
-#define _OBC_APP_ID_ 1
+#define _OBC_APP_ID_ 0
 #define _EPS_APP_ID_ 4
 #define _ADCS_APP_ID_ 2
 #define _COMMS_APP_ID_ 3

--- a/Services/system_header.h
+++ b/Services/system_header.h
@@ -12,23 +12,19 @@
  * GNU General Public License for more details.
  */
 
-/**
- * This header file is unique to the system being implemented. It just includes
- * system specific headers, and defines system parameters.
- */
+/*
+    Including this header will automatically find the wanted
+    sub-system header to include.
+*/
 
-#ifndef SYSTEM_H
-#define SYSTEM_H
-
-#include "demo.h"
-#include "demo_hal.h"
-
-#ifndef SYSTEM_APP_ID
-#define SYSTEM_APP_ID _DEMO_APP_ID_
+#ifdef SYSTEM_APP_ID
+    #if SYSTEM_APP_ID == _DEMO_APP_ID_
+        #include "ex2_demo_software/system.h"
+    #elif SYSTEM_APP_ID == _OBC_APP_ID_
+        #include "ex2_obc_software/system.h"
+    #else
+        #error Cannot include proper header due to SYSTEM_APP_ID being defined as an unimplemented value
+    #endif
+#else
+    #error SYSTEM_APP_ID is undefined
 #endif
-
-#define USE_LOCALHOST  // Define for local development, add other options when
-                       // available
-int main(int argc, char **argv);
-
-#endif /* SYSTEM_H */

--- a/Services/system_header.h
+++ b/Services/system_header.h
@@ -11,7 +11,11 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-
+/**
+ * @file system_header.h
+ * @author Andrew Rooney, Brandon Danyluk
+ * @date 2020-10-03
+ */
 /*
     Including this header will automatically find the wanted
     sub-system header to include.

--- a/Services/system_header.h
+++ b/Services/system_header.h
@@ -20,6 +20,8 @@
     Including this header will automatically find the wanted
     sub-system header to include.
 */
+#ifndef SYSTEM_HEADER_H
+#define SYSTEM_HEADER_H
 
 #ifdef SYSTEM_APP_ID
     #if SYSTEM_APP_ID == _DEMO_APP_ID_
@@ -31,4 +33,6 @@
     #endif
 #else
     #error SYSTEM_APP_ID is undefined
+#endif
+
 #endif


### PR DESCRIPTION
## [Clickup Task](app.clickup.com)(if applicable)

## Description of changes
f66d531285219d4b848ae964f79e3aa0e3e6af19 caused compilation errors for me building the demo app. I tracked it down to `SYSTEM_APP_ID` not being defined the entire time. The simple fix is to define the macro as a GCC argument so that it is guaranteed to be defined during the build, but when someone wants to fix the core issue at hand I added `system_header.h` to ensure that the value is always defined and that it will include the correct header every time when including the wanted system header.

## Testing done
* Docker now compiles project while previously it error'd out.
* I am able to send commands between the simulated ground station and services so nothing seems to be wrong there

## Merge checklist
- [x] Docker image or CCS Project builds with the changes
- [ ] Docker image or CCS Project runs with the changes
- [x] Can send commands from a mocked ground station/relevant changes tested
- [x] Changes have been reviewed
