### PR TITLE
new time_management subtype number

### DIFF
--- a/Services/include/time_management/time_management_service.h
+++ b/Services/include/time_management/time_management_service.h
@@ -23,8 +23,8 @@
 
 
 typedef enum {
-  GET_TIME = 0,
-  SET_TIME = 1
+  GET_TIME = 10,
+  SET_TIME = 11
 } Time_Management_Subtype;  // shared with EPS!
 
 SAT_returnState start_time_management_service(void);


### PR DESCRIPTION
New subtype numbers to match the ground station TC/TM. Note that EPS subport numbers were hardcoded so OBC ones had to change. Dependency with ex2_ground_station_software [branch](https://github.com/AlbertaSat/ex2_ground_station_software/compare/separate_time_commands).
