### PR TITLE
Add UHF configuration to general service

### DIFF
--- a/Services/include/general.h
+++ b/Services/include/general.h
@@ -25,7 +25,11 @@
 
 SAT_returnState start_general_service(void);
 
-typedef enum { REBOOT = 0 } General_Subtype; // shared with EPS!
+typedef enum {
+    REBOOT = 0,
+    GET_UHF_WATCHDOG_TIMEOUT,
+    SET_UHF_WATCHDOG_TIMEOUT,
+} General_Subtype; // shared with EPS!
 
 typedef enum { bootloader = 'B', golden = 'G', application = 'A' } reboot_mode;
 

--- a/Services/include/general.h
+++ b/Services/include/general.h
@@ -27,9 +27,9 @@ SAT_returnState start_general_service(void);
 
 typedef enum {
     REBOOT = 0,
-    GET_UHF_WATCHDOG_TIMEOUT,
-    SET_UHF_WATCHDOG_TIMEOUT,
-} General_Subtype; // shared with EPS!
+    GET_UHF_WATCHDOG_TIMEOUT = 1,
+    SET_UHF_WATCHDOG_TIMEOUT = 2,
+} General_Subtype;
 
 typedef enum { bootloader = 'B', golden = 'G', application = 'A' } reboot_mode;
 


### PR DESCRIPTION
Add general sub-services to change the frequency of the UHF watchdog timers.

I added this to the general service, NOT the UHF service because I think that this has more to do with the OBC system than the UHF system.

Merge after https://github.com/AlbertaSat/ex2_obc_software/pull/72